### PR TITLE
Add networking module example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# networking
+# Networking Module
+
+This repository contains a simple networking module designed for the
+[anonymOS](https://github.com/Jonathan-R-Anderson/internetcomputer)
+project.  The module exposes minimal wrappers for sending and receiving
+network packets using system calls only.  It is intended to be compiled
+with the `ldc2` cross‑compiler targeting `x86_64-unknown-elf`.
+
+## Building
+
+Use the provided `build.sh` script. It relies solely on `ldc2` and does
+not require any external libraries:
+
+```bash
+./build.sh
+```
+
+This produces `network_module.bin`, which can be linked into the OS or
+used by other components.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Simple build script using ldc2 cross compiler.
+# Targets x86_64-unknown-elf as used by anonymOS/internetcomputer.
+ldc2 -betterC -O1 -mtriple=x86_64-unknown-elf -c network_module.d -of=network_module.o
+ldc2 -betterC -O1 -mtriple=x86_64-unknown-elf network_module.o -of=network_module.bin
+

--- a/network_module.d
+++ b/network_module.d
@@ -1,0 +1,47 @@
+module network.network_module;
+
+/**
+ * Minimal networking module for anonymOS/internetcomputer.
+ * Provides send and receive wrappers around kernel network
+ * syscalls. This module is intended to be compiled using
+ * the D cross-compiler (ldc2 targeting x86_64-unknown-elf).
+ */
+
+extern(C):
+long do_syscall(ulong id, ulong a1, ulong a2, ulong a3, ulong a4, ulong a5, ulong a6);
+
+alias ulong size_t;
+
+enum SyscallID : ulong {
+    NetSend    = 44,
+    NetReceive = 45
+}
+
+struct NetPacket {
+    ubyte[1500] data;
+    size_t len;
+}
+
+/// Send data as a single network packet.
+long netSend(const(void)* buf, size_t len) {
+    NetPacket p;
+    if(len > p.data.length) len = p.data.length;
+    p.len = len;
+    p.data[0 .. len] = (*cast(const(ubyte)[1500]*)buf)[0 .. len];
+    return do_syscall(cast(ulong)SyscallID.NetSend, cast(ulong)&p, len, 0, 0, 0, 0);
+}
+
+/// Receive a network packet into the provided buffer.
+/// Returns number of bytes written or 0 if none available.
+size_t netReceive(void* buf, size_t buflen) {
+    NetPacket p;
+    auto ret = do_syscall(cast(ulong)SyscallID.NetReceive, cast(ulong)&p, p.data.length, 0, 0, 0, 0);
+    if(ret <= 0) return 0;
+    auto n = cast(size_t)ret;
+    if(n > buflen) n = buflen;
+    auto out = cast(ubyte*)buf;
+    out[0 .. n] = p.data[0 .. n];
+    return n;
+}
+
+


### PR DESCRIPTION
## Summary
- add minimal `network_module.d` with send/receive wrappers around kernel syscalls
- provide `build.sh` using the ldc2 cross-compiler
- document module usage in README

## Testing
- `./build.sh` *(fails: `ldc2` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685efbc0aa288327803b80a8d68b60cc